### PR TITLE
Add support for listing jobs associated with a user

### DIFF
--- a/girder/cumulus/plugin_tests/cluster_test.py
+++ b/girder/cumulus/plugin_tests/cluster_test.py
@@ -534,7 +534,7 @@ class ClusterTestCase(base.TestCase):
                          type='application/json', body={}, user=self._user)
         self.assertStatusOk(r)
 
-        expected_submit_call = [[[u'token', {u'status': u'running', u'userId': str(self._user['_id']), u'config': {u'_id': config_id, u'scheduler': {u'type': u'sge'}}, u'_id': cluster_id, u'name': u'test', u'template': u'default_cluster', u'type': u'ec2'}, {u'status': u'created', u'commands': [u''], u'name': u'test', u'onComplete': {u'cluster': u'terminate'}, u'clusterId': cluster_id, u'input': [
+        expected_submit_call = [[[u'token', {u'status': u'running', u'userId': str(self._user['_id']), u'config': {u'_id': config_id, u'scheduler': {u'type': u'sge'}}, u'_id': cluster_id, u'name': u'test', u'template': u'default_cluster', u'type': u'ec2'}, {u'status': u'created', u'userId': str(self._user['_id']), u'commands': [u''], u'name': u'test', u'onComplete': {u'cluster': u'terminate'}, u'clusterId': cluster_id, u'input': [
             {u'itemId': u'546a1844ff34c70456111185', u'path': u''}], u'output': [{u'itemId': u'546a1844ff34c70456111185'}], u'_id': job_id, u'log': []}, u'http://127.0.0.1/api/v1/jobs/%s/log' % job_id], {}]]
         self.assertCalls(submit.call_args_list, expected_submit_call)
 

--- a/girder/cumulus/server/models/job.py
+++ b/girder/cumulus/server/models/job.py
@@ -31,6 +31,7 @@ class Job(BaseModel):
 
     def initialize(self):
         self.name = 'jobs'
+        self.ensureIndices(['userId'])
 
     def validate(self, doc):
         if not doc['name']:
@@ -48,6 +49,9 @@ class Job(BaseModel):
             '_id': ObjectId(self.get_group_id())
         }
         doc = self.setGroupAccess(job, group, level=AccessType.ADMIN)
+
+        # Add the user id of the creator to indicate ownership
+        job['userId'] = user['_id']
 
         self.save(job)
 


### PR DESCRIPTION
Each job now stores the user id of the user that created it. This
is used to query the jobs associated with a user.