### PR TITLE
Cleanup validation of scheduler types

### DIFF
--- a/cumulus/constants.py
+++ b/cumulus/constants.py
@@ -48,10 +48,6 @@ class QueueType:
     SLURM = 'slurm'
     NEWT = 'newt'
 
-    @staticmethod
-    def is_valid_type(type):
-        return type == QueueType.SGE or type == QueueType.PBS
-
 
 class JobQueueState:
     QUEUED = 'queued'

--- a/girder/cumulus/plugin_tests/cluster_test.py
+++ b/girder/cumulus/plugin_tests/cluster_test.py
@@ -899,3 +899,30 @@ class ClusterTestCase(base.TestCase):
         # Assert that assetstore is gone
         self.assertIsNone(self.model('assetstore').load(cluster['assetstoreId']))
 
+    @mock.patch('cumulus.ssh.tasks.key.generate_key_pair.delay')
+    def test_create_scheduler_type(self, generate_key_pair):
+        trad_body = {
+            'config': {
+                'host': 'myhost',
+                'ssh': {
+                    'user': 'myuser'
+                },
+                'scheduler': {
+                    'type': 'bogus'
+                }
+            },
+            'name': 'mycluster',
+            'type': 'trad'
+        }
+        json_body = json.dumps(trad_body)
+        r = self.request('/clusters', method='POST',
+                         type='application/json', body=json_body, user=self._user)
+        self.assertStatus(r, 400)
+
+        trad_body['config']['scheduler']['type'] = 'slurm'
+        json_body = json.dumps(trad_body)
+        r = self.request('/clusters', method='POST',
+                         type='application/json', body=json_body, user=self._user)
+        self.assertStatus(r, 201)
+
+

--- a/girder/cumulus/server/cluster.py
+++ b/girder/cumulus/server/cluster.py
@@ -28,7 +28,7 @@ from girder.api.docs import addModel
 from girder.api.rest import RestException, getBodyJson, getCurrentUser
 from girder.models.model_base import ValidationException
 from .base import BaseResource
-from cumulus.constants import ClusterType, QueueType
+from cumulus.constants import ClusterType
 from .utility.cluster_adapters import get_cluster_adapter
 from cumulus.ssh.tasks.key import generate_key_pair
 from cumulus.common import update_dict
@@ -208,18 +208,6 @@ class Cluster(BaseResource):
         if cluster_type == ClusterType.EC2:
             cluster = self._create_ec2(params, body)
         elif cluster_type == ClusterType.TRADITIONAL:
-            scheduler_type = parse('config.scheduler.type').find(body)
-            if scheduler_type:
-                scheduler_type = scheduler_type[0].value
-            else:
-                scheduler_type = QueueType.SGE
-                config = body.setdefault('config', {})
-                scheduler = config.setdefault('scheduler', {})
-                scheduler['type'] = scheduler_type
-
-            if not QueueType.is_valid_type(scheduler_type):
-                raise RestException('Unsupported scheduler.', code=400)
-
             cluster = self._create_traditional(params, body)
         elif cluster_type == ClusterType.NEWT:
             cluster = self._create_newt(params, body)


### PR DESCRIPTION
Ensure that we have a consistent way of validating scheduler types
that allows the addition of additional schedulers via plugins.