### PR TITLE
Fix taskflow termination

### DIFF
--- a/cumulus/taskflow/__init__.py
+++ b/cumulus/taskflow/__init__.py
@@ -545,7 +545,8 @@ def task_success_handler(sender=None, **kwargs):
 
             # See if we have any follow on tasks
             to_run = taskflow._on_complete_lookup(sender.name)
-            if to_run:
+            # Only run follow on tasks if we aren't terminating
+            if to_run and taskflow.status() != TaskFlowState.TERMINATING:
                 to_run.delay()
 
             # Is the completion of this task going to complete the flow?

--- a/girder/taskflow/server/taskflows.py
+++ b/girder/taskflow/server/taskflows.py
@@ -197,15 +197,17 @@ class TaskFlows(Resource):
         self._model.save(taskflow)
         constructor = load_class(taskflow['taskFlowClass'])
         token = self.model('token').createToken(user=user, days=7)
-        taskflow = constructor(
+        taskflow_instance = constructor(
             id=str(taskflow['_id']),
             girder_token=token['_id'],
             girder_api_url=cumulus.config.girder.baseUrl)
 
+        # Set the meta data
+        taskflow_instance['meta'] = taskflow.get('meta', {})
         # Mark the taskflow as being used to termination
-        taskflow['terminate'] = True
+        taskflow_instance['terminate'] = True
 
-        taskflow.terminate()
+        taskflow_instance.terminate()
 
     @access.user
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)


### PR DESCRIPTION
Ensure that follow on tasks are not run during termination and that meta data is available during termination.