### PR TITLE
Adds ec2 placement group variable to ec2 role

### DIFF
--- a/cumulus/ansible/tasks/playbooks/roles/ec2-pod/tasks/main.yml
+++ b/cumulus/ansible/tasks/playbooks/roles/ec2-pod/tasks/main.yml
@@ -87,6 +87,7 @@
         ec2_pod_instance_name: "{{ item.key }}"
       exact_count: "{{ (item.value.count|default(1))|int }}"
       group: ec2_pod_{{ cluster_name }}
+      placement_group: "{{ placement_group | default(omit) }}"
       image: "{{ item.value.image|default(default_image) }}"
       instance_tags:
         Name: >-


### PR DESCRIPTION
If ```placement_group``` is added to the cluster params this will set the placement group on launch.  See #213 