### PR TITLE
Replaced deprecated assetstore.adapter.get event.

### DIFF
--- a/girder/newt/server/__init__.py
+++ b/girder/newt/server/__init__.py
@@ -23,6 +23,7 @@ from girder.api import access
 from girder.api.v1.assetstore import Assetstore
 from girder.constants import AssetstoreType, AccessType
 from girder.utility.model_importer import ModelImporter
+from girder.utility.assetstore_utilities import setAssetstoreAdapter
 from .rest import Newt, NewtAssetstore, create_assetstore
 from .constants import NEWT_BASE_URL
 
@@ -55,7 +56,7 @@ def create_assetstore_from_event(event):
 def load(info):
 
     AssetstoreType.NEWT = 'newt'
-    events.bind('assetstore.adapter.get', 'newt', getAssetstore)
+    setAssetstoreAdapter(AssetstoreType.NEWT, NewtAssetstoreAdapter)
     events.bind('assetstore.update', 'newt', updateAssetstore)
 
     (Assetstore.createAssetstore.description

--- a/girder/sftp/server/__init__.py
+++ b/girder/sftp/server/__init__.py
@@ -22,6 +22,7 @@ from girder.api import access
 from girder.api.v1.assetstore import Assetstore
 from girder.constants import AssetstoreType
 from girder.utility.model_importer import ModelImporter
+from girder.utility.assetstore_utilities import setAssetstoreAdapter
 
 from .assetstore import SftpAssetstoreAdapter
 from .credentials import retrieve_credentials
@@ -48,7 +49,7 @@ def updateAssetstore(event):
 def load(info):
 
     AssetstoreType.SFTP = 'sftp'
-    events.bind('assetstore.adapter.get', 'sftp', getAssetstore)
+    setAssetstoreAdapter(AssetstoreType.SFTP, SftpAssetstoreAdapter)
     events.bind('assetstore.update', 'sftp', updateAssetstore)
     events.bind('assetstore.sftp.credentials.get', 'sftp', retrieve_credentials)
 


### PR DESCRIPTION
Replaced assetstore.adapter.get event name with girder.utility.assetstore_utilities.setAssetstoreAdapter. Deprecation warnings no longer show up in girder logs when girder service is restarted on vagrant VM.