### PR TITLE
Remove -e option from girder-client install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ six==1.9.0
 jsonpath-rw==1.4.0
 enum34==1.0.4
 ansible==2.1
--e git+https://github.com/girder/girder.git#egg=girder-client&subdirectory=clients/python
+girder-client==2.0.0
 paramiko==1.16.0


### PR DESCRIPTION
As a GitHub URL was being provided the package was downloaded into /tmp and then symlinked. The problem is /tmp goes away on reboot! Not sure why -e was used in the first place.