### PR TITLE
fixed return value for ec2 running_instances

### DIFF
--- a/cumulus/ansible/tasks/providers/ec2.py
+++ b/cumulus/ansible/tasks/providers/ec2.py
@@ -120,9 +120,10 @@ class EC2Provider(CloudProvider):
 
         return inventory
 
-    def running_instances(self, cluster_id):
-        return len([host for host in self.get_instances(cluster_id).keys()
-                    if host != '_meta'])
+    def running_instances(self):
+        return len([host for host in self.ec2.instances.filter(Filters=[
+            {'Name': 'instance-state-name', 'Values': ['running']}])
+            if host != '_meta'])
 
     def get_master_instance(self, cluster_id):
         cluster_id = str(cluster_id)


### PR DESCRIPTION
looking at [HPCCloud issue 17](https://github.com/Kitware/HPCCloud/issues/17) I was getting an error back. This fixes that and returns the right value for number of running instances for a profile. 

I'm not sure why tests weren't catching this? 