### PR TITLE
Add support of job metadata property

### DIFF
--- a/girder/cumulus/plugin_tests/job_test.py
+++ b/girder/cumulus/plugin_tests/job_test.py
@@ -328,6 +328,33 @@ class JobTestCase(base.TestCase):
         }
         self.assertEqual(data, expected, 'Unexpected notification data')
 
+        body = {
+            'metadata': {
+                'my': 'data'
+            }
+        }
+
+        # Test update metadata property
+        r = self.request('/jobs/%s' % str(job_id), method='PATCH',
+                         type='application/json', body=json.dumps(body),
+                         user=self._cumulus)
+
+        self.assertTrue('metadata' in r.json)
+        self.assertEqual(r.json['metadata'], body['metadata'])
+
+        # Update again
+        body = {
+            'metadata': {
+                'my': 'data2',
+                'new': 1
+            }
+        }
+        r = self.request('/jobs/%s' % str(job_id), method='PATCH',
+                         type='application/json', body=json.dumps(body),
+                         user=self._cumulus)
+
+        self.assertTrue('metadata' in r.json)
+        self.assertEqual(r.json['metadata'], body['metadata'])
 
     def test_log(self):
         body = {

--- a/girder/cumulus/server/job.py
+++ b/girder/cumulus/server/job.py
@@ -251,6 +251,9 @@ class Job(BaseResource):
         if 'dir' in body:
             job['dir'] = body['dir']
 
+        if 'metadata' in body:
+            job['metadata'] = body['metadata']
+
         job = self._model.update_job(user, job)
 
         # Don't return the access object
@@ -268,7 +271,9 @@ class Job(BaseResource):
                 'description': 'The new status. (optional)'
             },
             'queueJobId': {'type': 'integer',
-                           'description': 'The native queue job id. (optional)'}
+                           'description': 'The native queue job id. (optional)'},
+            'metadata': {'type': 'object',
+                         'description': 'Application metadata.'}
         }
     }, 'jobs')
 

--- a/girder/cumulus/server/job.py
+++ b/girder/cumulus/server/job.py
@@ -273,7 +273,7 @@ class Job(BaseResource):
             'queueJobId': {'type': 'integer',
                            'description': 'The native queue job id. (optional)'},
             'metadata': {'type': 'object',
-                         'description': 'Application metadata.'}
+                         'description': 'Application metadata. (optional)'}
         }
     }, 'jobs')
 


### PR DESCRIPTION
This is a free formed property that can be using by applications to
store data associated with the job.

Fixes #327 