### PR TITLE
Add unbuffered option for SLURM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,11 @@ before_install:
     - pushd "${HOME}/build"
     - git clone https://github.com/girder/girder.git
     - export IGNORE_PLUGINS=celery_jobs,geospatial,google_analytics,hdfs_assetstore,jquery_widgets,meta
-    - pip install -r girder/requirements.txt
-    - pip install -r girder/requirements-dev.txt
-    - pip install girder/
+    - pushd girder
+    - pip install -r requirements.txt
+    - pip install -r requirements-dev.txt
+    - pip install .
+    - popd
     - CACHE=$HOME/.cache source $HOME/build/girder/scripts/install_mongo.sh
     - mkdir /tmp/db
     - mongod --dbpath=/tmp/db >/dev/null 2>/dev/null &

--- a/cumulus/templates/schedulers/slurm.sh
+++ b/cumulus/templates/schedulers/slurm.sh
@@ -29,4 +29,6 @@
 {% if constraint -%}
 #SBATCH --constraint={{constraint}}
 {% endif -%}
-
+{% if unbuffered is not defined or unbuffered -%}
+#SBATCH --unbuffered
+{% endif -%}

--- a/tests/cases/fixtures/job/slurm_submission_script.sh
+++ b/tests/cases/fixtures/job/slurm_submission_script.sh
@@ -11,6 +11,7 @@
 #SBATCH --output=dummy-123432423.o%j
 #SBATCH --error=dummy-123432423.e%j
 #SBATCH --workdir=
+#SBATCH --unbuffered
 
 ls
 sleep 20

--- a/tests/cases/fixtures/job/slurm_submission_script_nodes.sh
+++ b/tests/cases/fixtures/job/slurm_submission_script_nodes.sh
@@ -12,6 +12,7 @@
 #SBATCH --error=dummy-123432423.e%j
 #SBATCH --workdir=
 #SBATCH --nodes=12312312
+#SBATCH --unbuffered
 
 ls
 sleep 20

--- a/tests/cases/fixtures/job/slurm_submission_script_nodes_cores.sh
+++ b/tests/cases/fixtures/job/slurm_submission_script_nodes_cores.sh
@@ -13,6 +13,7 @@
 #SBATCH --workdir=
 #SBATCH --nodes=12312312
 #SBATCH --cpus-per-task=8
+#SBATCH --unbuffered
 
 ls
 sleep 20

--- a/tests/cases/fixtures/job/slurm_submission_script_nodes_gpus.sh
+++ b/tests/cases/fixtures/job/slurm_submission_script_nodes_gpus.sh
@@ -13,6 +13,7 @@
 #SBATCH --workdir=
 #SBATCH --nodes=12312312
 #SBATCH --gres=gpu:2
+#SBATCH --unbuffered
 
 ls
 sleep 20

--- a/tests/cases/fixtures/job/slurm_submission_script_number_of_slots.sh
+++ b/tests/cases/fixtures/job/slurm_submission_script_number_of_slots.sh
@@ -12,6 +12,7 @@
 #SBATCH --error=dummy-123432423.e%j
 #SBATCH --workdir=
 #SBATCH --ntasks=12312312
+#SBATCH --unbuffered
 
 ls
 sleep 20


### PR DESCRIPTION
By default use the --unbuffered option to ensure that data is available as soon as the job is complete.