### PR TITLE
Fix Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
     - git clone https://github.com/girder/girder.git
     - export IGNORE_PLUGINS=celery_jobs,geospatial,google_analytics,hdfs_assetstore,jquery_widgets,meta
     - pushd girder
-    - pip install -r requirements.txt
     - pip install -r requirements-dev.txt
     - pip install .
     - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
     - "2.7"
-    - "3.4"
+    - "3.5"
 
 cache:
   directories:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ botocore>=1.8.33
 boto==2.38.0
 boto3==1.3.0
 celery==3.1.20
-requests==2.7.0
+requests==2.14.2
 requests-toolbelt==0.3.0
 jsonschema==2.4.0
 easydict==1.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+botocore>=1.8.33
 boto==2.38.0
 boto3==1.3.0
 celery==3.1.20

--- a/tests/flake8.cfg
+++ b/tests/flake8.cfg
@@ -33,6 +33,7 @@ exclude: cumulus/taskflow/core/test/, cumulus/ansible/tasks/playbooks/library/gi
 #     D101 - Public class    (101) docstring missing.
 #     D102 - Public method   (102) docstring missing.
 #     D103 - Public function (103) docstring missing.
+#     D107 - __init__        (107) docstring missing.
 #     D200 - One-line docstrings should fit on one line with quotes.
 #     D201 - No blank lines allowed before (201) docstring.
 #     D202 - No blank lines allowed after  (202) docstring.
@@ -55,4 +56,4 @@ exclude: cumulus/taskflow/core/test/, cumulus/ansible/tasks/playbooks/library/gi
 #     N803 - Argument name should be lowercase.
 #     N806 - Variable in function should be lowercase.
 #     N812 - Lowercase imported as non lowercase.
-ignore: D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812
+ignore: D100,D101,D102,D103,D104,D105,D107,D200,D201,D202,D203,D204,D205,D208,D209,D300,D400,D401,D402,E123,E226,E241,N802,N803,N806,N812


### PR DESCRIPTION
Removed `pip install -r requirements.txt` from travis-ci for girder
because girder no longer has a requirements.txt file.