### PR TITLE
Import SettingKey from girder.settings

### DIFF
--- a/girder/newt/newt/rest.py
+++ b/girder/newt/newt/rest.py
@@ -24,7 +24,7 @@ from girder.api.describe import Description
 from girder.api.rest import Resource, RestException, getCurrentUser, getBodyJson
 from girder.api.rest import loadmodel
 from girder.api import access
-from girder.constants import SettingKey
+from girder.settings import SettingKey
 from girder.constants import AssetstoreType, AccessType
 from girder.api.docs import addModel
 from girder.models.setting import Setting

--- a/girder/sftp/sftp/rest.py
+++ b/girder/sftp/sftp/rest.py
@@ -23,7 +23,7 @@ import cherrypy
 from girder.api.describe import Description
 from girder.api.rest import Resource, RestException, getBodyJson, loadmodel
 from girder.api import access
-from girder.constants import SettingKey
+from girder.settings import SettingKey
 from girder.constants import AssetstoreType, AccessType
 from girder.api.docs import addModel
 from girder.utility.model_importer import ModelImporter


### PR DESCRIPTION
SettingKey was moved from girder.constants to
girder.settings a [couple of weeks ago](https://github.com/girder/girder/commit/0d7c7540aa0a32f15cfea8cc3b13862f1275f868#diff-7f4a310472d6da8cc00ee6afab5db27eR324). Update the
code here to reflect that.

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>