### PR TITLE
Add TokenScopes to access decorators

### DIFF
--- a/girder/cluster_filesystem/cluster_filesystem/__init__.py
+++ b/girder/cluster_filesystem/cluster_filesystem/__init__.py
@@ -134,7 +134,7 @@ def _decode_id(func=None, key='id'):
     return wrapped
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @_decode_id(key='parentId')
 def _folder_before(conn, path, cluster, encoded_id, **rest):
     folders = []
@@ -157,7 +157,7 @@ def _folder_before(conn, path, cluster, encoded_id, **rest):
 
     return folders
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @_decode_id
 def _folder_id_before(conn, path, cluster, encoded_id):
     for entry in conn.list(path):
@@ -179,7 +179,7 @@ def _folder_id_before(conn, path, cluster, encoded_id):
             }
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @_decode_id(key='folderId')
 def _item_before(conn, path, cluster, encoded_id):
     items = []
@@ -200,7 +200,7 @@ def _item_before(conn, path, cluster, encoded_id):
 
     return items
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @_decode_id
 def _item_id_before(conn, path, cluster, encoded_id):
     file_stat = conn.stat(path)
@@ -221,7 +221,7 @@ def _item_id_before(conn, path, cluster, encoded_id):
     }
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @_decode_id
 def _item_files_before(conn, path, cluster, encoded_id):
     file_stat = conn.stat(path)
@@ -242,7 +242,7 @@ def _item_files_before(conn, path, cluster, encoded_id):
     }
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 def _file_id_before(event):
     return _item_files_before(event)
 

--- a/girder/cumulus/cumulus_plugin/aws.py
+++ b/girder/cumulus/cumulus_plugin/aws.py
@@ -29,7 +29,7 @@ from cumulus.aws.ec2 import get_ec2_client
 
 from girder.api import access
 from girder.api.describe import Description
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.api.docs import addModel
 from girder.api.rest import RestException, getBodyJson, ModelImporter,\
     getCurrentUser
@@ -49,7 +49,7 @@ def _filter(profile):
     return profile
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_WRITE)
 @loadmodel(model='user', level=AccessType.WRITE)
 def create_profile(user, params):
     body = getBodyJson()
@@ -112,7 +112,7 @@ create_profile.description = (
         required=True, paramType='body'))
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_WRITE)
 @loadmodel(model='user', level=AccessType.READ)
 @loadmodel(model='aws', plugin='cumulus',  map={'profileId': 'profile'},
            level=AccessType.WRITE)
@@ -147,7 +147,7 @@ delete_profile.description = (
            required=True))
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_WRITE)
 @loadmodel(model='user', level=AccessType.READ)
 @loadmodel(model='aws', plugin='cumulus',  map={'profileId': 'profile'},
            level=AccessType.WRITE)
@@ -191,7 +191,7 @@ update_profile.description = (
         required=True, paramType='body'))
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @loadmodel(model='user', level=AccessType.READ)
 def get_profiles(user, params):
     user = getCurrentUser()
@@ -210,7 +210,7 @@ get_profiles.description = (
     .param('id', 'The id of the user', required=True, paramType='path'))
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @loadmodel(model='user', level=AccessType.READ)
 @loadmodel(model='aws', plugin='cumulus',  map={'profileId': 'profile'},
            level=AccessType.WRITE)
@@ -237,7 +237,7 @@ status.description = (
     .responseClass('AwsProfileStatus'))
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @loadmodel(model='user', level=AccessType.READ)
 @loadmodel(model='aws', plugin='cumulus',  map={'profileId': 'profile'},
            level=AccessType.WRITE)
@@ -264,7 +264,7 @@ running_instances.description = (
     .responseClass('AwsProfileRunningInstances'))
 
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @loadmodel(model='user', level=AccessType.READ)
 @loadmodel(model='aws', plugin='cumulus',  map={'profileId': 'profile'},
            level=AccessType.WRITE)

--- a/girder/cumulus/cumulus_plugin/cluster.py
+++ b/girder/cumulus/cumulus_plugin/cluster.py
@@ -24,7 +24,7 @@ from bson.objectid import ObjectId
 
 from girder.api import access
 from girder.api.describe import Description
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.api.docs import addModel
 from girder.api.rest import RestException, getBodyJson, loadmodel
 from girder.models.model_base import ValidationException
@@ -59,7 +59,7 @@ class Cluster(BaseResource):
         # TODO Findout how to get plugin name rather than hardcoding it
         self._model = ModelImporter.model('cluster', 'cumulus')
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def handle_log_record(self, id, params):
         user = self.getCurrentUser()
 
@@ -125,7 +125,7 @@ class Cluster(BaseResource):
 
         return cluster
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create(self, params):
         body = getBodyJson()
         # Default ec2 cluster
@@ -213,7 +213,7 @@ class Cluster(BaseResource):
 
         return body
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='cluster', plugin='cumulus', level=AccessType.ADMIN)
     def start(self, cluster, params):
         body = self._get_body()
@@ -252,7 +252,7 @@ class Cluster(BaseResource):
             'body', 'Parameter used when starting cluster', paramType='body',
             dataType='ClusterStartParams', required=False))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='cluster', plugin='cumulus', level=AccessType.ADMIN)
     def launch(self, cluster, params):
 
@@ -271,7 +271,7 @@ class Cluster(BaseResource):
         'id',
         'The cluster id to start.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='cluster', plugin='cumulus', level=AccessType.ADMIN)
     def provision(self, cluster, params):
 
@@ -317,7 +317,7 @@ class Cluster(BaseResource):
 
         return getattr(adapter, process)()
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def update(self, id, params):
         body = getBodyJson()
         user = self.getCurrentUser()
@@ -385,7 +385,7 @@ class Cluster(BaseResource):
             paramType='body')
         .notes('Internal - Used by Celery tasks'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def status(self, id, params):
         user = self.getCurrentUser()
         cluster = self._model.load(id, user=user, level=AccessType.READ)
@@ -410,7 +410,7 @@ class Cluster(BaseResource):
                'The cluster id to get the status of.', paramType='path')
         .responseClass('ClusterStatus'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def terminate(self, id, params):
         user = self.getCurrentUser()
         cluster = self._model.load(id, user=user, level=AccessType.ADMIN)
@@ -428,7 +428,7 @@ class Cluster(BaseResource):
             'id',
             'The cluster to terminate.', paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def log(self, id, params):
         user = self.getCurrentUser()
         offset = 0
@@ -453,7 +453,7 @@ class Cluster(BaseResource):
             'The offset to start getting entries at.', required=False,
             paramType='query'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def submit_job(self, id, jobId, params):
         job_id = jobId
         user = self.getCurrentUser()
@@ -499,7 +499,7 @@ class Cluster(BaseResource):
             'The properties to template on submit.', dataType='object',
             paramType='body'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def get(self, id, params):
         user = self.getCurrentUser()
         cluster = self._model.load(id, user=user, level=AccessType.ADMIN)
@@ -515,7 +515,7 @@ class Cluster(BaseResource):
             'id',
             'The cluster id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def delete(self, id, params):
         user = self.getCurrentUser()
 
@@ -532,7 +532,7 @@ class Cluster(BaseResource):
         Description('Delete a cluster and its configuration')
         .param('id', 'The cluster id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def find(self, params):
         user = self.getCurrentUser()
         query = {}

--- a/girder/cumulus/cumulus_plugin/job.py
+++ b/girder/cumulus/cumulus_plugin/job.py
@@ -22,7 +22,7 @@ import cumulus
 
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.constants import AccessType, SortDir
+from girder.constants import AccessType, SortDir, TokenScope
 from girder.api.docs import addModel
 from girder.api.rest import RestException, getBodyJson, loadmodel
 from girder.utility.model_importer import ModelImporter
@@ -57,7 +57,7 @@ class Job(BaseResource):
 
         return job
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create(self, params):
         user = self.getCurrentUser()
 
@@ -195,7 +195,7 @@ class Job(BaseResource):
             'The job parameters in JSON format.', dataType='JobParameters',
             paramType='body', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def terminate(self, id, params):
         (user, token) = self.getCurrentUser(returnToken=True)
         job = self._model.load(id, user=user, level=AccessType.ADMIN)
@@ -225,7 +225,7 @@ class Job(BaseResource):
         Description('Terminate a job')
         .param('id', 'The job id', paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def update(self, id, params):
         user = self.getCurrentUser()
         body = getBodyJson()
@@ -287,7 +287,7 @@ class Job(BaseResource):
             paramType='body')
         .notes('Internal - Used by Celery tasks'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def status(self, id, params):
         user = self.getCurrentUser()
 
@@ -314,7 +314,7 @@ class Job(BaseResource):
         .param('id', 'The job id.', paramType='path')
         .responseClass('JobStatus'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def append_to_log(self, id, params):
         user = self.getCurrentUser()
 
@@ -332,7 +332,7 @@ class Job(BaseResource):
 
     append_to_log.description = None
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def log(self, id, params):
         user = self.getCurrentUser()
         offset = 0
@@ -356,7 +356,7 @@ class Job(BaseResource):
             'The offset to start getting entries at.', required=False,
             paramType='query'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def output(self, id, params):
         user = self.getCurrentUser()
 
@@ -401,7 +401,7 @@ class Job(BaseResource):
             'The offset to start getting entries at.', required=False,
             paramType='query'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def get(self, id, params):
         user = self.getCurrentUser()
         job = self._model.load(id, user=user, level=AccessType.READ)
@@ -419,7 +419,7 @@ class Job(BaseResource):
             'id',
             'The job id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='job', plugin='cumulus', level=AccessType.ADMIN)
     @describeRoute(
         Description('Delete a job')
@@ -452,7 +452,7 @@ class Job(BaseResource):
 
         self._model.remove(job)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def find(self, params):
         user = self.getCurrentUser()
 

--- a/girder/cumulus/cumulus_plugin/script.py
+++ b/girder/cumulus/cumulus_plugin/script.py
@@ -22,7 +22,7 @@ import json
 from girder.api import access
 from girder.api.describe import Description
 from girder.api.docs import addModel
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.api.rest import RestException
 from girder.utility.model_importer import ModelImporter
 from .base import BaseResource
@@ -45,7 +45,7 @@ class Script(BaseResource):
 
         return config
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def import_script(self, id, params):
         user = self.getCurrentUser()
         lines = cherrypy.request.body.read().decode('utf8').splitlines()
@@ -72,7 +72,7 @@ class Script(BaseResource):
             required=True, paramType='body')
         .consumes('text/plain'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create(self, params):
         user = self.getCurrentUser()
 
@@ -111,7 +111,7 @@ class Script(BaseResource):
             'The JSON contain script parameters',
             required=True, paramType='body', dataType='Script'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def get(self, id, params):
         user = self.getCurrentUser()
 
@@ -129,7 +129,7 @@ class Script(BaseResource):
             'The id of the script to get',
             required=True, paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def delete(self, id, params):
         user = self.getCurrentUser()
         script = self._model.load(id, user=user, level=AccessType.ADMIN)
@@ -142,7 +142,7 @@ class Script(BaseResource):
             'id',
             'The script id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def update_access(self, id, params):
         user = self.getCurrentUser()
 

--- a/girder/cumulus/cumulus_plugin/volume.py
+++ b/girder/cumulus/cumulus_plugin/volume.py
@@ -23,7 +23,7 @@ from bson.objectid import ObjectId
 
 from girder.api import access
 from girder.api.describe import Description
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.api.docs import addModel
 from girder.api.rest import RestException, getCurrentUser, getBodyJson
 from girder.api.rest import loadmodel
@@ -74,7 +74,7 @@ class Volume(BaseResource):
 
         return self._model.create_ebs(user, profileId, name, zone, size, fs)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.WRITE)
     def patch(self, volume, params):
         body = getBodyJson()
@@ -106,7 +106,7 @@ class Volume(BaseResource):
             'The properties to use to create the volume.',
             required=True, paramType='body'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create(self, params):
         body = getBodyJson()
 
@@ -164,7 +164,7 @@ class Volume(BaseResource):
             dataType='VolumeParameters',
             required=True, paramType='body'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.READ)
     def get(self, volume, params):
 
@@ -176,7 +176,7 @@ class Volume(BaseResource):
             'id',
             'The volume id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def find(self, params):
         user = getCurrentUser()
         query = {}
@@ -200,7 +200,7 @@ class Volume(BaseResource):
         .param('limit', 'The max number of volumes to return',
                paramType='query', required=False, default=50))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(map={'clusterId': 'cluster'}, model='cluster', plugin='cumulus',
                level=AccessType.ADMIN)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
@@ -243,7 +243,7 @@ class Volume(BaseResource):
 
     attach_complete.description = None
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(map={'clusterId': 'cluster'}, model='cluster', plugin='cumulus',
                level=AccessType.ADMIN)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
@@ -317,7 +317,7 @@ class Volume(BaseResource):
             dataType='AttachParameters',
             paramType='body'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
     def detach(self, volume, params):
 
@@ -374,7 +374,7 @@ class Volume(BaseResource):
             'The id of the attached volume', required=True,
             paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
     def detach_complete(self, volume, params):
 
@@ -401,7 +401,7 @@ class Volume(BaseResource):
 
     detach_complete.description = None
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
     def delete(self, volume, params):
         if 'clusterId' in volume:
@@ -452,14 +452,14 @@ class Volume(BaseResource):
         Description('Delete a volume')
         .param('id', 'The volume id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
     def delete_complete(self, volume, params):
         self._model.remove(volume)
 
     delete_complete.description = None
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='volume', plugin='cumulus', level=AccessType.ADMIN)
     def get_status(self, volume, params):
         return {'status': volume['status']}
@@ -468,7 +468,7 @@ class Volume(BaseResource):
         Description('Get the status of a volume')
         .param('id', 'The volume id.', paramType='path', required=True))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def append_to_log(self, id, params):
         user = getCurrentUser()
 
@@ -480,7 +480,7 @@ class Volume(BaseResource):
 
     append_to_log.description = None
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def log(self, id, params):
         user = getCurrentUser()
         offset = 0

--- a/girder/newt/newt/rest.py
+++ b/girder/newt/newt/rest.py
@@ -25,7 +25,7 @@ from girder.api.rest import Resource, RestException, getCurrentUser, getBodyJson
 from girder.api.rest import loadmodel
 from girder.api import access
 from girder.settings import SettingKey
-from girder.constants import AssetstoreType, AccessType
+from girder.constants import AssetstoreType, AccessType, TokenScope
 from girder.api.docs import addModel
 from girder.models.setting import Setting
 from girder.models.user import User
@@ -139,7 +139,7 @@ class Newt(Resource):
         Description('Authenticate with Girder using a NEWT session id.')
         .param('sessionId', 'The NEWT session id', paramType='path'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     def session_id(self, params):
         user = getCurrentUser()
 
@@ -172,7 +172,7 @@ class NewtAssetstore(Resource):
         self.route('POST', (), self.create)
         self.route('POST', (':id', 'files'), self.create_file)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='assetstore')
     def create_file(self, assetstore, params):
         params = getBodyJson()
@@ -222,7 +222,7 @@ class NewtAssetstore(Resource):
         .param('body', 'The parameter to create the file with.', required=True,
                paramType='body', dataType='CreateFileParams'))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create(self, params):
         params = getBodyJson()
         self.requireParams(('name', 'machine'), params)

--- a/girder/sftp/sftp/rest.py
+++ b/girder/sftp/sftp/rest.py
@@ -24,7 +24,7 @@ from girder.api.describe import Description
 from girder.api.rest import Resource, RestException, getBodyJson, loadmodel
 from girder.api import access
 from girder.settings import SettingKey
-from girder.constants import AssetstoreType, AccessType
+from girder.constants import AssetstoreType, AccessType, TokenScope
 from girder.api.docs import addModel
 from girder.utility.model_importer import ModelImporter
 
@@ -36,7 +36,7 @@ class SftpAssetstoreResource(Resource):
         self.route('POST', (), self.create_assetstore)
         self.route('POST', (':id', 'files'), self.create_file)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     def create_assetstore(self, params):
         """Create a new SFTP assetstore."""
 
@@ -74,7 +74,7 @@ class SftpAssetstoreResource(Resource):
                paramType='body', dataType='CreateAssetstoreParams'))
 
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='assetstore')
     def create_file(self, assetstore, params):
         params = getBodyJson()

--- a/girder/taskflow/taskflow/taskflows.py
+++ b/girder/taskflow/taskflow/taskflows.py
@@ -28,7 +28,7 @@ from girder.api.rest import RestException, getBodyJson, loadmodel,\
 from girder.api import access
 from girder.api.docs import addModel
 from girder.api.describe import describeRoute, Description
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.utility.model_importer import ModelImporter
 import sys
 from bson.objectid import ObjectId
@@ -80,7 +80,7 @@ class TaskFlows(Resource):
         }
     }, 'taskflows')
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='taskflow', plugin='taskflow')
     @describeRoute(
         Description('Create the taskflow')
@@ -112,7 +112,7 @@ class TaskFlows(Resource):
 
         return taskflow
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='taskflow', plugin='taskflow')
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.WRITE)
     @describeRoute(
@@ -141,7 +141,7 @@ class TaskFlows(Resource):
 
         return taskflow
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
         Description('Get the taskflow status')
@@ -153,7 +153,7 @@ class TaskFlows(Resource):
     def status(self, taskflow, params):
         return {'status': taskflow['status']}
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_READ)
     @filtermodel(model='taskflow', plugin='taskflow')
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
@@ -174,7 +174,7 @@ class TaskFlows(Resource):
 
         return taskflow
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.WRITE)
     @describeRoute(None)
     def log(self, taskflow, params):
@@ -184,7 +184,7 @@ class TaskFlows(Resource):
 
         self._model.append_to_log(taskflow, json.loads(body))
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.WRITE)
     @describeRoute(
         Description('Terminate the taskflow ')
@@ -212,7 +212,7 @@ class TaskFlows(Resource):
 
         taskflow_instance.terminate()
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(
         Description('Start the taskflow ')
@@ -243,7 +243,7 @@ class TaskFlows(Resource):
 
         workflow.start(**params)
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='taskflow', plugin='taskflow')
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(
@@ -289,7 +289,7 @@ class TaskFlows(Resource):
         cherrypy.response.status = 202
         return taskflow
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_READ)
     @filtermodel(model='task', plugin='taskflow')
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
@@ -321,7 +321,7 @@ class TaskFlows(Resource):
         }
     }, 'taskflows')
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='task', plugin='taskflow')
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
@@ -348,7 +348,7 @@ class TaskFlows(Resource):
 
         return task
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='taskflow', plugin='taskflow')
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.WRITE)
     @describeRoute(None)
@@ -366,13 +366,13 @@ class TaskFlows(Resource):
         return self._model.collection.find_one_and_update(
             query, update, return_document=ReturnDocument.AFTER)
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(None)
     def delete_finished(self, taskflow, params):
         self._model.delete(taskflow)
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
         Description('Get log entries for task')
@@ -411,7 +411,7 @@ class TaskFlows(Resource):
         }
     }, 'taskflows')
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(
         Description('Get access list for a taskflow')
@@ -421,7 +421,7 @@ class TaskFlows(Resource):
     def get_access(self, taskflow, params):
         return taskflow.get('access', {'groups': [], 'users': []})
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(
         Description('Set access list for a taskflow given a list of user and \
@@ -437,7 +437,7 @@ class TaskFlows(Resource):
         return self._model.set_access(user, taskflow,
                                       body['users'], body['groups'], True)
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(
         Description('Append access to a taskflow and its tasks')
@@ -452,7 +452,7 @@ class TaskFlows(Resource):
         return self._model.patch_access(user, taskflow,
                                         body['users'], body['groups'])
 
-    @access.user
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='taskflow', plugin='taskflow', level=AccessType.ADMIN)
     @describeRoute(
         Description('Revoke access to a taskflow and its tasks')

--- a/girder/taskflow/taskflow/tasks.py
+++ b/girder/taskflow/taskflow/tasks.py
@@ -25,7 +25,7 @@ from girder.api.rest import RestException, loadmodel, filtermodel, getBodyJson,\
 from girder.api.rest import Resource
 from girder.api import access
 from girder.api.describe import Description, describeRoute
-from girder.constants import AccessType
+from girder.constants import AccessType, TokenScope
 from girder.utility.model_importer import ModelImporter
 
 class Tasks(Resource):
@@ -42,7 +42,7 @@ class Tasks(Resource):
         # TODO Findout how to get plugin name rather than hardcoding it
         self._model = ModelImporter.model('task', 'taskflow')
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @filtermodel(model='task', plugin='taskflow')
     @loadmodel(model='task', plugin='taskflow', level=AccessType.WRITE)
     @describeRoute(
@@ -71,7 +71,7 @@ class Tasks(Resource):
 
         return self._model.update_task(user, task, status=status)
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='task', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
         Description('Get the task status')
@@ -80,7 +80,7 @@ class Tasks(Resource):
     def status(self, task, params):
         return {'status': task['status']}
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_READ)
     @filtermodel(model='task', plugin='taskflow')
     @loadmodel(model='task', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
@@ -93,7 +93,7 @@ class Tasks(Resource):
     def get(self, task, params):
         return task
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_WRITE)
     @loadmodel(model='task', plugin='taskflow', level=AccessType.WRITE)
     @describeRoute(None)
     def log(self, task, params):
@@ -104,7 +104,7 @@ class Tasks(Resource):
 
         self._model.append_to_log(task, json.loads(body))
 
-    @access.token
+    @access.user(scope=TokenScope.DATA_READ)
     @loadmodel(model='task', plugin='taskflow', level=AccessType.READ)
     @describeRoute(
         Description('Get log entries for task')


### PR DESCRIPTION
If a girder api key is used in which "Allow all actions on behalf of my
user" is not selected, token scopes are required in order for
`getCurrentUser()` to not return `None`. When the token scopes are not
present, various errors at different points where `getCurrentUser()` is
called/used occur.

Add the token scopes so that these errors do not occur.

Additionally, the `@access.token` decorators were changed to
`@access.user` decorators, since `@access.user` is usually what is
needed. `@access.token` is primarily used for tokens that may or may not
be associated with a user. But in nearly every case, we do want the
tokens to be associated with users, so `@access.user` is preferable.