### PR TITLE
Add a user route to lookup assetstores by name

### DIFF
--- a/cumulus/transport/files/__init__.py
+++ b/cumulus/transport/files/__init__.py
@@ -18,7 +18,6 @@
 ###############################################################################
 import requests
 from jsonpath_rw import parse
-import sys
 
 import cumulus
 from cumulus.common import check_status
@@ -72,21 +71,19 @@ def get_assetstore_id(girder_token, cluster):
     elif r.status_code == 400:
         body = r.json()
         if body.get('field') == 'name' and body.get('type') == 'validation':
-            assetstores_url = '%s/assetstore' % (cumulus.config.girder.baseUrl)
-            params = {'limit': sys.maxsize}
+            assetstores_url = '%s/assetstore/lookup' % (
+                cumulus.config.girder.baseUrl)
+            params = {'name': cluster['_id']}
             r = requests.get(assetstores_url, params=params, headers=headers)
             check_status(r)
             assetstores = r.json()
-            assetstore_id = None
-            for assetstore in assetstores:
-                if assetstore.get('name') == cluster['_id']:
-                    assetstore_id = assetstore['_id']
-                    break
-            if assetstore_id is None:
+            if len(assetstores) == 0:
                 raise Exception(
                     'Could not find assetstore with name "%s" even though '
                     'it should already exist.' % cluster['_id']
                 )
+
+            assetstore_id = assetstores[0]['_id']
         else:
             check_status(r)
 

--- a/girder/cumulus/cumulus_plugin/__init__.py
+++ b/girder/cumulus/cumulus_plugin/__init__.py
@@ -20,6 +20,7 @@
 from girder.plugin import GirderPlugin
 from girder.utility.model_importer import ModelImporter
 
+from .assetstore import lookupAssetstore
 from .cluster import Cluster
 from .job import Job
 from .script import Script
@@ -46,5 +47,9 @@ class CumulusPlugin(GirderPlugin):
         info['apiRoot'].jobs = Job()
         info['apiRoot'].scripts = Script()
         info['apiRoot'].volumes = Volume()
+
+        # Add a user route to lookup assetstores by name.
+        info['apiRoot'].assetstore.route('GET', ('lookup', ), lookupAssetstore)
+
         # Augment user resource with aws profiles
         aws.load(info['apiRoot'])

--- a/girder/cumulus/cumulus_plugin/assetstore.py
+++ b/girder/cumulus/cumulus_plugin/assetstore.py
@@ -1,0 +1,11 @@
+from girder.api import access
+from girder.api.describe import Description, autoDescribeRoute
+from girder.models.assetstore import Assetstore
+
+@access.user
+@autoDescribeRoute(
+    Description('Retrieve assetstores with a given name.')
+    .param('name', 'The assetstore name', required=True)
+    .errorResponse())
+def lookupAssetstore(name, params):
+    return Assetstore().find({'name': name})

--- a/girder/cumulus/cumulus_plugin/assetstore.py
+++ b/girder/cumulus/cumulus_plugin/assetstore.py
@@ -16,6 +16,6 @@ def lookupAssetstore(name, params):
         return assetstores
     else:
         safe_only = lambda assetstore : {
-            field: assetstore[field] for field in ('_id', 'name')
+            field: assetstore[field] for field in ('_id', 'name', 'type')
         }
         return list(map(safe_only, assetstores))

--- a/girder/cumulus/cumulus_plugin/assetstore.py
+++ b/girder/cumulus/cumulus_plugin/assetstore.py
@@ -1,11 +1,21 @@
 from girder.api import access
 from girder.api.describe import Description, autoDescribeRoute
+from girder.api.rest import getCurrentUser
+from girder.constants import TokenScope
 from girder.models.assetstore import Assetstore
 
-@access.user
+@access.user(scope=TokenScope.DATA_READ)
 @autoDescribeRoute(
     Description('Retrieve assetstores with a given name.')
     .param('name', 'The assetstore name', required=True)
     .errorResponse())
 def lookupAssetstore(name, params):
-    return Assetstore().find({'name': name})
+    assetstores = Assetstore().find({'name': name})
+    user = getCurrentUser()
+    if user.get('admin', False):
+        return assetstores
+    else:
+        safe_only = lambda assetstore : {
+            field: assetstore[field] for field in ('_id', 'name')
+        }
+        return list(map(safe_only, assetstores))


### PR DESCRIPTION
Admins are the only ones allowed to fetch the list of assetstores.
When creating an assetstore for a cluster, if another process has
created it there may be a need to lookup the assetstore as a regular
user. This additional rout allows for it.