### PR TITLE
Add find_cluster() to cluster model

### DIFF
--- a/girder/cumulus/cumulus_plugin/cluster.py
+++ b/girder/cumulus/cumulus_plugin/cluster.py
@@ -534,21 +534,7 @@ class Cluster(BaseResource):
 
     @access.user(scope=TokenScope.DATA_READ)
     def find(self, params):
-        user = self.getCurrentUser()
-        query = {}
-
-        if 'type' in params:
-            query['type'] = params['type']
-
-        limit = params.get('limit', 50)
-
-        clusters = self._model.find(query=query)
-
-        clusters = self._model.filterResultsByPermission(clusters, user,
-                                                         AccessType.ADMIN,
-                                                         limit=int(limit))
-
-        return [self._model.filter(cluster, user) for cluster in clusters]
+        return self._model.find_cluster(params, user=self.getCurrentUser())
 
     find.description = (
         Description('Search for clusters with certain properties')

--- a/girder/cumulus/cumulus_plugin/models/cluster.py
+++ b/girder/cumulus/cumulus_plugin/models/cluster.py
@@ -54,11 +54,19 @@ class Cluster(BaseModel):
                                           fields=fields, exc=exc)
         return model
 
-    def find(self, query=None, offset=0, limit=0, timeout=None,
-             fields=None, sort=None, **kwargs):
-        return [cluster for cluster in
-                super(Cluster, self).find(query, offset, limit, timeout,
-                                          fields, sort, **kwargs)]
+    def find_cluster(self, params, user, **kwargs):
+        if params is None:
+            params = {}
+
+        query = {}
+        if 'type' in params:
+            query['type'] = params['type']
+
+        limit = int(params.get('limit', 50))
+        clusters = self.findWithPermissions(query, limit=limit, user=user,
+                                            level=AccessType.ADMIN, **kwargs)
+
+        return [self.filter(cluster, user) for cluster in clusters]
 
     def filter(self, cluster, user, passphrase=True):
         cluster = super(Cluster, self).filter(doc=cluster, user=user)


### PR DESCRIPTION
Move the logic for finding a cluster into the model, so that other
girder plugins can use the same logic via `find_cluster()`.

This also utilizes `findWithPermissions` for ensuring correct
permissions, rather than filtering the results ourselves.