### PR TITLE
Remove python2 from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.6"
 
 cache:


### PR DESCRIPTION
Girder no longer supports python2, so we should not try to test it
anymore. Remove it.